### PR TITLE
Added extension method to get poster image as memory stream from Url …

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,6 @@ A C# API wrapper for <a href="http://omdbapi.com/" target="_blank">omdbapi.com</
 
 Example:
 
-<pre>omdb newOmdb = new omdb();<br/>
-movie newMovie = await newOmdb.getMovie("Blade Runner");</pre>
+<pre>var omdb = new Omdb();<br/>
+var movie = await omdb.GetMovie("Blade Runner");<br/>
+var posterStream = await movie.GetPosterStream();</pre>

--- a/omdbSharp/MovieExtensionMethods.cs
+++ b/omdbSharp/MovieExtensionMethods.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace OmdbSharp
+{
+    public static class MovieExtensionMethods
+    {
+        public static async Task<MemoryStream> GetPosterStream(this Movie movie)
+        {
+            if (movie.Poster == null)
+                return null;
+
+            using (var client = new HttpClient())
+            {
+                var response = client.GetAsync(movie.Poster).Result;
+                if (response == null || response.StatusCode != HttpStatusCode.OK)
+                {
+                    return null;
+                }
+
+                var stream = await response.Content.ReadAsStreamAsync();
+                var memoryStream = new MemoryStream();
+                await stream.CopyToAsync(memoryStream);
+                return memoryStream;
+            }
+        }
+    }
+}


### PR DESCRIPTION
…supplied by API.

This bypasses the need for an API key to get the poster image.